### PR TITLE
Handle more kinds of proxy connection errors

### DIFF
--- a/lib/wavefront/client/common/proxy_connection_handler.rb
+++ b/lib/wavefront/client/common/proxy_connection_handler.rb
@@ -52,7 +52,7 @@ module Wavefront
       begin
         connect unless @reconnecting_socket
         @reconnecting_socket.puts(line_data.encode('utf-8'))
-      rescue SocketError => error
+      rescue => error
         if reconnect
           @reconnecting_socket = nil
           # Try to resend


### PR DESCRIPTION
Updates the exception handler for `ProxyConnectionHandler` to handle
more kinds of errors, not just `SocketError`.  The harm in retrying more
kinds of errors seems quite small, and the harm in *not* retrying is
rather large.

We've seen in production that `Errno::EPIPE`, which is not a
`SocketError`, is quite common.  Not attempting to reconnect the
connection in that case is quite bad, since that's not the kind of error
that resolves itself.