### PR TITLE
Fix method that sends delta counters

### DIFF
--- a/lib/wavefront/client/entities/metrics/wavefront_metric_sender.rb
+++ b/lib/wavefront/client/entities/metrics/wavefront_metric_sender.rb
@@ -41,6 +41,6 @@ module WavefrontMetricSender
     if !name.start_with?(Wavefront::DELTA_PREFIX) && !name.start_with?(Wavefront::DELTA_PREFIX_2)
       name = Wavefront::DELTA_PREFIX + name
     end
-    send_metric(name, value, None, source, tags)
+    send_metric(name, value, nil, source, tags)
   end
 end


### PR DESCRIPTION
Updates the `send_delta_counter` method to use the value `nil` as a
timestamp instead of `None`.  `None` seems to be a reference to a Python
concept; the Ruby equivalent is `nil`.